### PR TITLE
Support interpreting hex and octal escape sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ way more sophisticated. It also supports parsing the following:
 * Single quoted strings (`'hello world'`) which preserve any whitespace characters and
   only accept escape sequences `\\` and `\'`, e.g. `'let\'s go'`.
 * Double quoted strings (`"hello world"`) which preserve any whitespace characters and
-  support common escape sequences such as `\t\r\n` etc., e.g. `"hi there\nworld!"`.
+  support common escape sequences such as `\t\r\n` etc., hex escape sequences such as `\x20`
+  and octal escape sequences such as `\040`, e.g. `"hi there\nworld!"`.
 * Unquoted strings are terminated at the next (unescaped) whitespace character and
-  support common escape sequences such as `\t\r\n` etc., e.g. `hi\ there\nworld!`.
+  support common escape sequences just like double quoted strings, e.g. `hi\ there\nworld!`.
 * Ignores excessive whitespace around arguments, such as trailing whitespace or
   multiple spaces between arguments.
 * Makes no assumptions about your input encoding, so this works with binary data

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -181,4 +181,86 @@ class SplitTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(array("echo", "let's go"), $args);
     }
+
+    public function testSingleStringWithInterpretedEscapes()
+    {
+        $args = Arguments\split('hello\\\\');
+
+        $this->assertEquals(array("hello\\"), $args);
+    }
+
+    public function testSingleStringWithInterpretedIncompleteEscapes()
+    {
+        $args = Arguments\split('hello\\');
+
+        $this->assertEquals(array("hello\\"), $args);
+    }
+
+    public function testSingleStringWithInterpretedHexEscapes()
+    {
+        $args = Arguments\split('hello\x20world');
+
+        $this->assertEquals(array("hello world"), $args);
+    }
+
+    public function testSingleStringWithInterpretedIncompleteHexEscapesEnd()
+    {
+        $args = Arguments\split('hello\x9');
+
+        $this->assertEquals(array("hello\t"), $args);
+    }
+
+    public function testSingleStringWithInterpretedIncompleteHexEscapesMiddle()
+    {
+        $args = Arguments\split('hello\x9world');
+
+        $this->assertEquals(array("hello\tworld"), $args);
+    }
+
+    public function testSingleStringWithInterpretedOctalEscapes()
+    {
+        $args = Arguments\split('hello\040world');
+
+        $this->assertEquals(array("hello world"), $args);
+    }
+
+    public function testSingleStringWithInterpretedShortOctalEscapes()
+    {
+        $args = Arguments\split('hello\40world');
+
+        $this->assertEquals(array("hello world"), $args);
+    }
+
+    public function testSingleStringWithUninterpretedNumberIsNotAnOctalEscape()
+    {
+        $args = Arguments\split('hello\\999world');
+
+        $this->assertEquals(array("hello999world"), $args);
+    }
+
+    // "\n"\n"\n"
+    public function testSingleStringWithCombinedDoubleQuotedPartsWithInterpretedEscapes()
+    {
+        $args = Arguments\split('"\n"\n"\n"');
+
+        $this->assertEquals(array("\n\n\n"), $args);
+    }
+
+    // '\n'\n'\n'
+    public function testSingleStringWithCombinedSingleQuotedPartsWithInterpretedEscapesOnlyInInnerUnquotedPart()
+    {
+        $s = "'";
+        $args = Arguments\split($s . '\n' . $s . '\n' . $s . '\n' . $s);
+
+        $this->assertEquals(array("\\n\n\\n"), $args);
+    }
+
+    // \n'\n'\n
+    public function testSingleStringWithCombinedSingleQuotedPartsWithInterpretedEscapesOnlyInOuterUnquotedParts()
+    {
+        $s = "'";
+        $args = Arguments\split('\n' . $s . '\n' . $s . '\n');
+
+        $this->assertEquals(array("\n\\n\n"), $args);
+    }
 }


### PR DESCRIPTION
Support interpreting hex and octal escape sequences.

Marking this as a BC break because this changes how the user input will be interpreted.

Closes #2
Closes #4