### PR TITLE
Support Unicode escape sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,18 @@ way more sophisticated. It also supports parsing the following:
 * Single quoted strings (`'hello world'`) which preserve any whitespace characters and
   only accept escape sequences `\\` and `\'`, e.g. `'let\'s go'`.
 * Double quoted strings (`"hello world"`) which preserve any whitespace characters and
-  support common escape sequences such as `\t\r\n` etc., hex escape sequences such as `\x20`
-  and octal escape sequences such as `\040`, e.g. `"hi there\nworld!"`.
+  support common escape sequences such as `\t\r\n` etc., unicode escape sequences
+  such as `\u0020`, hex escape sequences such as `\x20` and
+  octal escape sequences such as `\040`, e.g. `"hi there\nworld!"`.
 * Unquoted strings are terminated at the next (unescaped) whitespace character and
   support common escape sequences just like double quoted strings, e.g. `hi\ there\nworld!`.
 * Ignores excessive whitespace around arguments, such as trailing whitespace or
   multiple spaces between arguments.
-* Makes no assumptions about your input encoding, so this works with binary data
-  as well as full UTF-8 (Unicode) support.
+* Makes very few assumptions about your input encoding otherwise, so that input
+  is allowed to contain raw binary data as well as full UTF-8 (Unicode) support.
+  Unicode characters may either be given as normal UTF-8 strings such as
+  `hällö` or can be given as unicode escape sequences in double quoted and
+  unquoted strings, e.g. `h\u00e4ll\u00f6`. 
 
 For example, this means that the following also parses as expected:
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -56,6 +56,19 @@ function split($command)
             } else {
                 // we're not within any quotes or within a "double quoted" string
                 if ($c === '\\' && isset($command[$i + 1])) {
+                    if ($command[$i + 1] === 'u') {
+                        // this looks like a unicode escape sequence
+                        // use JSON parser to interpret this
+                        $c = json_decode('"' . substr($command, $i, 6) . '"');
+                        if ($c !== null) {
+                            // on success => use interpreted and skip sequence
+                            $argument .= stripcslashes($part) . $c;
+                            $part = '';
+                            $i += 5;
+                            continue;
+                        }
+                    }
+
                     // escaped characters will be interpreted when part is complete
                     $part .= $command[$i] . $command[$i + 1];
                     ++$i;

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -238,6 +238,48 @@ class SplitTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array("hello999world"), $args);
     }
 
+    public function testSingleStringWithInterpretedUnicodeEscapes()
+    {
+        $args = Arguments\split('hello\u0020world');
+
+        $this->assertEquals(array("hello world"), $args);
+    }
+
+    public function testSingleStringWithInterpretedUnicodeEscapesBackslash()
+    {
+        $args = Arguments\split('hello\u005Cx00');
+
+        $this->assertEquals(array("hello\\x00"), $args);
+    }
+
+    public function testSingleStringWithInterpretedUnicodeEscapesEndLowerCase()
+    {
+        $args = Arguments\split('hell\u00f6');
+
+        $this->assertEquals(array("hellö"), $args);
+    }
+
+    public function testSingleStringWithInterpretedUnicodeEscapesEndUpperCase()
+    {
+        $args = Arguments\split('hell\u00F6');
+
+        $this->assertEquals(array("hellö"), $args);
+    }
+
+    public function testSingleStringWithUninterpretedCharacterIsNotAnUnicodeEscape()
+    {
+        $args = Arguments\split('hell\\uworld');
+
+        $this->assertEquals(array("helluworld"), $args);
+    }
+
+    public function testSingleStringWithUninterpretedCharacterIsNotAnUnicodeEscapeEnd()
+    {
+        $args = Arguments\split('hell\\u');
+
+        $this->assertEquals(array("hellu"), $args);
+    }
+
     // "\n"\n"\n"
     public function testSingleStringWithCombinedDoubleQuotedPartsWithInterpretedEscapes()
     {


### PR DESCRIPTION
Support Unicode escape sequences.

Marking this as a BC break because this changes how the user input will be interpreted.

Closes #3