### PR TITLE
Throw UnclosedQuotesException on unbalanced quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ But many other tools may need similar parsing during their runtime.
 * [Quickstart example](#quickstart-example)
 * [Usage](#usage)
   * [split()](#split)
+  * [UnclosedQuotesException](#unclosedquotesexception)
 * [Install](#install)
 * [License](#license)
 
@@ -152,9 +153,10 @@ $args = Arguments\split($line);
 assert(count($args) === 0);
 ```
 
-Parsing an input line that has a missing quote (i.e. a quoted argument started
-without passing an ending quote), this will throw a `RuntimeException`. This
-can be useful to ask the user to correct their input:
+Parsing an input line that has unbalanced quotes (i.e. a quoted argument started
+without passing ending quotes), this will throw an
+[`UnclosedQuotesException`](#unclosedquotesexception).
+This can be useful to ask the user to correct their input:
 
 ```php
 $line = 'sendmail "hello world';
@@ -162,10 +164,18 @@ $line = 'sendmail "hello world';
 try {
     Arguments\split($line);
     // throws RuntimeException
-} catch (RuntimeException $e) {
+} catch (Arguments\UnclosedQuotesException $e) {
     echo 'Please check your input.';
 }
 ```
+
+### UnclosedQuotesException
+
+The `UnclosedQuotesException` will be raised by the [`split()`](#split)
+function when the input line has unbalanced quotes (i.e. a quoted argument
+started without passing ending quotes).
+
+This class extends PHP's `RuntimeException`.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ try {
 closing quotes will actually be marked as escaped.
 Either handle these yourself or wrap this block in another `try-catch`.
 
+The `getPosition(): int` method can be used to get the character position of
+the quotes within the input string.
+In the previous example, this will be at `$line[9]`:
+
+```php
+$pos = $e->getPosition();
+
+assert($pos === 9);
+assert($line[$pos] === $e->getQuotes());
+```
+
 ## Install
 
 The recommended way to install this library is [through Composer](http://getcomposer.org).

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The `UnclosedQuotesException` will be raised by the [`split()`](#split)
 function when the input line has unbalanced quotes (i.e. a quoted argument
 started without passing ending quotes).
 
-This class extends PHP's `RuntimeException`.
+This class extends PHP's [`InvalidArgumentException`](http://php.net/manual/en/class.invalidargumentexception.php).
 
 The `getQuotes(): string` method can be used to get the quotes this argument
 started with:

--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ try {
 }
 ```
 
+See also the following chapter if you want to (try to) correct the user input
+line automatically.
+
 ### UnclosedQuotesException
 
 The `UnclosedQuotesException` will be raised by the [`split()`](#split)
@@ -176,6 +179,31 @@ function when the input line has unbalanced quotes (i.e. a quoted argument
 started without passing ending quotes).
 
 This class extends PHP's `RuntimeException`.
+
+The `getQuotes(): string` method can be used to get the quotes this argument
+started with:
+
+```php
+$quotes = $e->getQuotes();
+```
+
+For example, this can be used to (try to) correct the user input line like this:
+
+```php
+$line = 'sendmail "hello world';
+
+try {
+    $args = Arguments\split($line);
+    // throws RuntimeException
+} catch (Arguments\UnclosedQuotesException $e) {
+    // retry parsing with closing quotes appended
+    $args = Arguments\split($line . $e->getQuotes());
+}
+```
+
+> Note: The input line may end with a backslash in which case the appended
+closing quotes will actually be marked as escaped.
+Either handle these yourself or wrap this block in another `try-catch`.
 
 ## Install
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": ">=5.3"
     },
     "autoload": {
-        "files": [ "src/functions.php" ]
+        "files": [ "src/functions.php" ],
+        "psr-4": { "Clue\\Arguments\\": "src/" }
     }
 }

--- a/examples/interactive.php
+++ b/examples/interactive.php
@@ -16,7 +16,7 @@ while (true) {
     // try to parse command line or complain
     try {
         $args = Clue\Arguments\split($line);
-    } catch (\RuntimeException $e) {
+    } catch (Clue\Arguments\UnclosedQuotesException $e) {
         echo 'Invalid command line. Missing quotes?' . PHP_EOL;
         continue;
     }

--- a/src/UnclosedQuotesException.php
+++ b/src/UnclosedQuotesException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Clue\Arguments;
+
+use RuntimeException;
+
+class UnclosedQuotesException extends RuntimeException
+{
+
+}

--- a/src/UnclosedQuotesException.php
+++ b/src/UnclosedQuotesException.php
@@ -7,32 +7,45 @@ use RuntimeException;
 class UnclosedQuotesException extends RuntimeException
 {
     private $quotes;
+    private $position;
 
     /**
      * @internal
      * @param string     $quotes
+     * @param int        $position
      * @param ?string    $message
      * @param int        $code
      * @param ?Exception $previous
      */
-    public function __construct($quotes, $message = null, $code = 0, $previous = null)
+    public function __construct($quotes, $position, $message = null, $code = 0, $previous = null)
     {
         if ($message === null) {
-            $message = 'Still in quotes (' . $quotes  . ')';
+            $message = 'Still in quotes (' . $quotes  . ') from position ' . $position;
         }
 
         parent::__construct($message, $code, $previous);
 
         $this->quotes = $quotes;
+        $this->position = $position;
     }
 
     /**
-     * Returns the qutoes this argument started with
+     * Returns the quotes this argument started with
      *
      * @return string
      */
     public function getQuotes()
     {
         return $this->quotes;
+    }
+
+    /**
+     * Returns the character position of the quotes within the input
+     *
+     * @return int
+     */
+    public function getPosition()
+    {
+        return $this->position;
     }
 }

--- a/src/UnclosedQuotesException.php
+++ b/src/UnclosedQuotesException.php
@@ -6,5 +6,33 @@ use RuntimeException;
 
 class UnclosedQuotesException extends RuntimeException
 {
+    private $quotes;
 
+    /**
+     * @internal
+     * @param string     $quotes
+     * @param ?string    $message
+     * @param int        $code
+     * @param ?Exception $previous
+     */
+    public function __construct($quotes, $message = null, $code = 0, $previous = null)
+    {
+        if ($message === null) {
+            $message = 'Still in quotes (' . $quotes  . ')';
+        }
+
+        parent::__construct($message, $code, $previous);
+
+        $this->quotes = $quotes;
+    }
+
+    /**
+     * Returns the qutoes this argument started with
+     *
+     * @return string
+     */
+    public function getQuotes()
+    {
+        return $this->quotes;
+    }
 }

--- a/src/UnclosedQuotesException.php
+++ b/src/UnclosedQuotesException.php
@@ -2,9 +2,9 @@
 
 namespace Clue\Arguments;
 
-use RuntimeException;
+use InvalidArgumentException;
 
-class UnclosedQuotesException extends RuntimeException
+class UnclosedQuotesException extends InvalidArgumentException
 {
     private $quotes;
     private $position;

--- a/src/functions.php
+++ b/src/functions.php
@@ -100,7 +100,7 @@ function split($command)
 
         // end of argument reached. Still in quotes is a parse error.
         if ($inQuote !== null) {
-            throw new UnclosedQuotesException('Still in quotes (' . $inQuote  . ')');
+            throw new UnclosedQuotesException($inQuote);
         }
 
         // add remaining part to current argument

--- a/src/functions.php
+++ b/src/functions.php
@@ -100,7 +100,7 @@ function split($command)
 
         // end of argument reached. Still in quotes is a parse error.
         if ($inQuote !== null) {
-            throw new \RuntimeException('Still in quotes (' . $inQuote  . ')');
+            throw new UnclosedQuotesException('Still in quotes (' . $inQuote  . ')');
         }
 
         // add remaining part to current argument

--- a/src/functions.php
+++ b/src/functions.php
@@ -33,6 +33,7 @@ function split($command)
         }
 
         $inQuote = null;
+        $quotePosition = 0;
         $argument = '';
         $part = '';
 
@@ -84,6 +85,7 @@ function split($command)
                 } elseif ($inQuote === null && ($c === '"' || $c === "'")) {
                     // start of quotes found
                     $inQuote = $c;
+                    $quotePosition = $i;
 
                     // previous unquoted part should be interpreted
                     $argument .= stripcslashes($part);
@@ -100,7 +102,7 @@ function split($command)
 
         // end of argument reached. Still in quotes is a parse error.
         if ($inQuote !== null) {
-            throw new UnclosedQuotesException($inQuote);
+            throw new UnclosedQuotesException($inQuote, $quotePosition);
         }
 
         // add remaining part to current argument

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -142,6 +142,16 @@ class SplitTest extends PHPUnit_Framework_TestCase
         Arguments\split('hello "world');
     }
 
+    public function testSimpleStringWithUnbalancedDoubleQuotesThrowsWithCorrectQuotes()
+    {
+        try {
+            Arguments\split('hello "world');
+            $this->fail();
+        } catch (Arguments\UnclosedQuotesException $e) {
+            $this->assertEquals('"', $e->getQuotes());
+        }
+    }
+
     public function testSingleStringWithDoubleQuotesAndDoubleEscape()
     {
         $bs = "\\";

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -97,7 +97,7 @@ class SplitTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException Clue\Arguments\UnclosedQuotesException
      */
     public function testSingleStringWithUnbalancedDoubleQuotesThrows()
     {
@@ -105,7 +105,7 @@ class SplitTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException Clue\Arguments\UnclosedQuotesException
      */
     public function testSingleStringWithUnbalancedSingleQuotesThrows()
     {
@@ -113,7 +113,7 @@ class SplitTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException Clue\Arguments\UnclosedQuotesException
      */
     public function testSimpleStringWithUnbalancedSingleQuotesThrows()
     {
@@ -135,7 +135,7 @@ class SplitTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException Clue\Arguments\UnclosedQuotesException
      */
     public function testSimpleStringWithUnbalancedDoubleQuotesThrows()
     {

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -149,6 +149,7 @@ class SplitTest extends PHPUnit_Framework_TestCase
             $this->fail();
         } catch (Arguments\UnclosedQuotesException $e) {
             $this->assertEquals('"', $e->getQuotes());
+            $this->assertEquals(6, $e->getPosition());
         }
     }
 

--- a/tests/UnclosedQuotesExceptionTest.php
+++ b/tests/UnclosedQuotesExceptionTest.php
@@ -6,15 +6,15 @@ class UnclosedQuotesExceptionTest extends PHPUnit_Framework_TestCase
 {
     public function testCtorWithOnlyQuotesAppliesMessage()
     {
-        $e = new UnclosedQuotesException('"');
+        $e = new UnclosedQuotesException('"', 2);
 
         $this->assertEquals('"', $e->getQuotes());
-        $this->assertEquals('Still in quotes (")', $e->getMessage());
+        $this->assertEquals('Still in quotes (") from position 2', $e->getMessage());
     }
 
     public function testCtorAcceptsQuotesAndMessage()
     {
-        $e = new UnclosedQuotesException('\'', 'test');
+        $e = new UnclosedQuotesException('\'', 2, 'test');
 
         $this->assertEquals('\'', $e->getQuotes());
         $this->assertEquals('test', $e->getMessage());

--- a/tests/UnclosedQuotesExceptionTest.php
+++ b/tests/UnclosedQuotesExceptionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Clue\Arguments\UnclosedQuotesException;
+
+class UnclosedQuotesExceptionTest extends PHPUnit_Framework_TestCase
+{
+    public function testCtorWithOnlyQuotesAppliesMessage()
+    {
+        $e = new UnclosedQuotesException('"');
+
+        $this->assertEquals('"', $e->getQuotes());
+        $this->assertEquals('Still in quotes (")', $e->getMessage());
+    }
+
+    public function testCtorAcceptsQuotesAndMessage()
+    {
+        $e = new UnclosedQuotesException('\'', 'test');
+
+        $this->assertEquals('\'', $e->getQuotes());
+        $this->assertEquals('test', $e->getMessage());
+    }
+}


### PR DESCRIPTION
Throw UnclosedQuotesException on unbalanced quotes which includes `getQuotes()` and `getPosition()` accessors.

This is a BC break because this class extends `InvalidArgumentException` instead of the previous `RuntimeException`.