### PR TITLE
Custom argument separator chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
 /vendor/
+.idea

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,11 @@
     "autoload": {
         "files": [ "src/functions.php" ],
         "psr-4": { "Clue\\Arguments\\": "src/" }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.1.5"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,19 +6,22 @@ namespace Clue\Arguments;
  * Splits the given command line string into an array of command arguments
  *
  * @param string $command command line string
+ * @param array  $optionalArgumentSeparatorChars array of chars like [",", "|"] to treat as argument separators
+ *
  * @return string[] array of command line argument strings
- * @throws \RuntimeException
  */
-function split($command)
+function split($command, $optionalArgumentSeparatorChars = array())
 {
     // whitespace characters count as argument separators
-    static $ws = array(
+    static $defaultArgumentSeparatorChars = array(
         ' ',
         "\r",
         "\n",
         "\t",
         "\v",
     );
+
+    $ws = array_merge($defaultArgumentSeparatorChars, $optionalArgumentSeparatorChars);
 
     $i = 0;
     $args = array();

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -2,7 +2,7 @@
 
 use Clue\Arguments;
 
-class SplitTest extends PHPUnit_Framework_TestCase
+class SplitTest extends PHPUnit\Framework\TestCase
 {
     public function testEmptyString()
     {

--- a/tests/UnclosedQuotesExceptionTest.php
+++ b/tests/UnclosedQuotesExceptionTest.php
@@ -2,7 +2,7 @@
 
 use Clue\Arguments\UnclosedQuotesException;
 
-class UnclosedQuotesExceptionTest extends PHPUnit_Framework_TestCase
+class UnclosedQuotesExceptionTest extends PHPUnit\Framework\TestCase
 {
     public function testCtorWithOnlyQuotesAppliesMessage()
     {


### PR DESCRIPTION
This PR updates `split` to accept an array of optional chars to treat as argument separators.

This allows parsing of strings like
`a,b,c,d` ==> `[ 'a','b','c','d' ]`
`"a,b",c, d"` ==> `[ 'a,b','c','d' ]`

Usage:
`\Clue\Arguments\split($commandLine);`  //Same as before
`\Clue\Arguments\split($commandLine, [ "," ]);`  //Now possible
