### PR TITLE
Run tests on PHP 8, PHP 7.4 and PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.github/workflows/ export-ignore
+/.gitignore export-ignore
+/examples/ export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           php-version: ${{ matrix.php }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     strategy:
       matrix:
         php:
+          - 7.4
+          - 7.3
           - 7.2
           - 7.1
           - 7.0
@@ -34,6 +36,5 @@ jobs:
       - uses: azjezz/setup-hhvm@v1
         with:
           version: lts-3.30
-      - run: hhvm $(which composer) require phpunit/phpunit:^5 --dev --no-interaction # requires legacy phpunit
       - run: hhvm $(which composer) install
       - run: hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ $ composer require clue/arguments:^2.0
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^6.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "autoload": {
         "files": [ "src/functions.php" ],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
-        <testsuite>
+        <testsuite name="Arguments test suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Arguments test suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/SplitTest.php
+++ b/tests/SplitTest.php
@@ -96,27 +96,21 @@ class SplitTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(array('he"llo'), $args);
     }
 
-    /**
-     * @expectedException Clue\Arguments\UnclosedQuotesException
-     */
     public function testSingleStringWithUnbalancedDoubleQuotesThrows()
     {
+        $this->setExpectedException('Clue\Arguments\UnclosedQuotesException');
         Arguments\split('"hello');
     }
 
-    /**
-     * @expectedException Clue\Arguments\UnclosedQuotesException
-     */
     public function testSingleStringWithUnbalancedSingleQuotesThrows()
     {
+        $this->setExpectedException('Clue\Arguments\UnclosedQuotesException');
         Arguments\split("'hello");
     }
 
-    /**
-     * @expectedException Clue\Arguments\UnclosedQuotesException
-     */
     public function testSimpleStringWithUnbalancedSingleQuotesThrows()
     {
+        $this->setExpectedException('Clue\Arguments\UnclosedQuotesException');
         Arguments\split("echo let's go");
     }
 
@@ -134,11 +128,9 @@ class SplitTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(array('hello'), $args);
     }
 
-    /**
-     * @expectedException Clue\Arguments\UnclosedQuotesException
-     */
     public function testSimpleStringWithUnbalancedDoubleQuotesThrows()
     {
+        $this->setExpectedException('Clue\Arguments\UnclosedQuotesException');
         Arguments\split('hello "world');
     }
 
@@ -315,5 +307,22 @@ class SplitTest extends PHPUnit\Framework\TestCase
         $args = Arguments\split('\n' . $s . '\n' . $s . '\n');
 
         $this->assertEquals(array("\n\\n\n"), $args);
+    }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
     }
 }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.
This pull request builds on top of #13.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0 php vendor/bin/phpunit
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

............................................                      44 / 44 (100%)

Time: 00:00.006, Memory: 6.00 MB

OK (44 tests, 47 assertions)
```